### PR TITLE
Added support for the dependencies available on Spring Initializr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,15 @@
 # generator-spring [![Build Status](https://secure.travis-ci.org/tomaslin/generator-spring.png?branch=master)](https://travis-ci.org/tomaslin/generator-spring)
 
-A generator for [Yeoman](http://yeoman.io).
+A [Yeoman](http://yeoman.io) generator for scaffolding and bootstrapping [Spring Boot](http://projects.spring.io/spring-boot/) and [Spring Cloud](http://projects.spring.io/spring-cloud/) applications. Provides the same selectable options as [Spring Initializr](http://start.spring.io), but with and interactive CLI interface so your hands can stay where they belong, on the keyboard!
 
 
 ## Getting Started
 
-### What is Yeoman?
+### Yeoman
 
-Trick question. It's not a thing. It's this guy:
+Yeoman is a scaffolding tool for modern webapps.
 
-![](http://i.imgur.com/JHaAlBJ.png)
-
-Basically, he wears a top hat, lives in your computer, and waits for you to tell him what kind of application you wish to create.
-
-Not every new computer comes with a Yeoman pre-installed. He lives in the [npm](https://npmjs.org) package repository. You only have to ask for him once, then he packs up and moves into your hard drive. *Make sure you clean up, he likes new and shiny things.*
+**Install Yeoman**
 
 ```
 $ npm install -g yo
@@ -21,9 +17,9 @@ $ npm install -g yo
 
 ### Yeoman Generators
 
-Yeoman travels light. He didn't pack any generators when he moved in. You can think of a generator like a plug-in. You get to choose what type of application you wish to create, such as a Backbone application or even a Chrome extension.
+Generators are [Node.js](https://nodejs.org) modules that serve as framework specific plugins for Yeoman.
 
-To install generator-spring from npm, run:
+**Install generator-spring**
 
 ```
 $ npm install -g generator-spring
@@ -34,13 +30,27 @@ Finally, initiate the generator:
 ```
 $ yo spring
 ```
+The interactive CLI menu will guide the way.
 
-### Getting To Know Yeoman
+### Extras
 
-Yeoman has a heart of gold. He's a person with feelings and opinions, but he's very easy to work with. If you think he's too opinionated, he can be easily convinced.
+Creates a REST endpoint
 
-If you'd like to get to know Yeoman better and meet some of his friends, [Grunt](http://gruntjs.com) and [Bower](http://bower.io), check out the complete [Getting Started Guide](https://github.com/yeoman/yeoman/wiki/Getting-Started).
+```
+$ yo spring:rest
+```
 
+Creates a REST endpoint with HATEOAS support *(has dependency on choosing the hateoas starter option)*
+
+```
+$ yo spring:hateoas
+```
+
+Creates an intial Thymeleaf view *(has dependency on choosing the Thyemleaf starter option)*
+
+```
+$ yo spring:route
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Creates a REST endpoint with HATEOAS support *(has dependency on choosing the ha
 $ yo spring:hateoas
 ```
 
-Creates an intial Thymeleaf view *(has dependency on choosing the Thyemleaf starter option)*
+Creates an initial Thymeleaf view *(has dependency on choosing the Thyemleaf starter option)*
 
 ```
 $ yo spring:route

--- a/app/index.js
+++ b/app/index.js
@@ -351,6 +351,12 @@ SpringGenerator.prototype.askFor = function askFor() {
         this.postgresql = hasDatabase('postgresql');
 
         // Spring Cloud
+        prompts.push({
+            type: 'string',
+            name: 'usesCloud',
+            message: 'usesCloud',
+            default: false
+        });
         var hasCloud = function(cloudStarter) {
             return props.cloud.indexOf(cloudStarter) !== -1;
         };
@@ -373,6 +379,7 @@ SpringGenerator.prototype.askFor = function askFor() {
         this.awsMessaging = hasCloud('awsMessaging');
         this.cloudBus = hasCloud('cloudBus');
         this.cloudSecurity = hasCloud('cloudSecurity');
+        this.usesCloud = props.cloud.length > 0;
 
         // I/O
         var hasIO = function(ioStarter) {

--- a/app/index.js
+++ b/app/index.js
@@ -35,111 +35,369 @@ SpringGenerator.prototype.askFor = function askFor() {
         '..........+88888888888888888888888+..........\n' +
         '...........,888888888888888888888:...........\n' +
         '.............DD888888888888888DD.............\n' +
-        chalk.red('\nWelcome to the Spring Boot Generator\n\n')));
+        chalk.yellow('\nWelcome to the Spring Boot Generator\n\nLets get started!\n\n')));
+
 
     var prompts = [
         {
             type: 'string',
             name: 'bootVersion',
-            message: '(1/6) What version of Spring Boot would you like to use?',
-            default: '0.5.0.M5'
-        },
-        {
+            message: 'Enter Spring Boot version:',
+            default: '1.2.5.RELEASE'
+        }, {
             type: 'string',
             name: 'packageName',
-            message: '(2/6) What is your default package name?',
+            message: 'Enter default package name:',
             default: 'com.myapp'
-        },
-        {
+        }, {
             type: 'string',
             name: 'baseName',
-            message: '(3/6) What is the base name of app?',
+            message: 'Enter base name of app:',
             default: 'app'
-        },
-        {
+        }, {
+            type: 'string',
+            name: 'javaVersion',
+            message: 'Enter Java version:',
+            default: '1.8'
+        }, {
             type: 'checkbox',
-            name: 'starters',
-            message: '(4/6) select your starters',
+            name: 'coreWeb',
+            message: 'Select Core/Web Dependencies:',
             choices: [
                 {
+                    name: 'Web',
+                    value: 'web'
+                }, {
                     name: 'Jetty (Tomcat will be uninstalled)',
                     value: 'jetty'
-                },
-                {
-                    name: 'Actuator',
-                    value: 'actuator'
-                },
-                {
-                    name: 'Aop',
+                }, {
+                    name: 'Security',
+                    value: 'security'
+                }, {
+                    name: 'AOP',
                     value: 'aop'
-                },
-                {
-                    name: 'Batch',
-                    value: 'batch'
-                },
-                {
-                    name: 'Data-jpa',
-                    value: 'jpa'
-                },
-                {
-                    name: 'Integration',
-                    value: 'integration'
-                },
-                {
-                    name: 'Hateoas',
+                },  {
+                    name: 'Websocket',
+                    value: 'websocket'
+                }, {
+                    name: 'Jersey (JAX-RS)',
+                    value: 'jersey'
+                }, {
+                    name: 'Rest Repositories',
+                    value: 'rest'
+                }, {
+                    name: 'Hypermedia (HATEOAS)',
                     value: 'hateoas'
-                },
+                }, {
+                    name: 'Mobile',
+                    value: 'mobile'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'templates',
+            message: 'Select Template Engine:',
+            choices: [
+                {
+                    name: 'Thymeleaf',
+                    value: 'thymeleaf'
+                }, {
+                    name: 'Groovy Templates',
+                    value: 'gtemplates'
+                }, {
+                    name: 'Mustache',
+                    value: 'mustache'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'data',
+            message: 'Select Data support:',
+            choices: [
                 {
                     name: 'Jdbc',
                     value: 'jdbc'
-                },
-                {
-                    name: 'Logging',
-                    value: 'logging'
-                },
-                {
-                    name: 'Security',
-                    value: 'security'
-                },
-                {
-                    name: 'Websocket',
-                    value: 'websocket'
+                }, {
+                    name: 'JPA',
+                    value: 'jpa'
+                }, {
+                    name: 'MongoDB',
+                    value: 'mongodb'
+                }, {
+                    name: 'Redis',
+                    value: 'redis'
+                },  {
+                    name: 'Solr',
+                    value: 'solr'
+                }, {
+                    name: 'Elasticsearch',
+                    value: 'elasticsearch'
                 }
             ]
-        },{
+        }, {
+            type: 'checkbox',
+            name: 'database',
+            message: 'Select Database support:',
+            choices: [
+                {
+                    name: 'H2',
+                    value: 'h2'
+                }, {
+                    name: 'HSQLDB',
+                    value: 'hsqldb'
+                }, {
+                    name: 'Apache Derby',
+                    value: 'derby'
+                }, {
+                    name: 'MySQL',
+                    value: 'mysql'
+                }, {
+                    name: 'PostgreSQL',
+                    value: 'postgresql'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'cloud',
+            message: 'Select Spring Cloud support:',
+            choices: [
+                {
+                    name: 'Cloud Connectors',
+                    value: 'connectors'
+                }, {
+                    name: 'Cloud Bootstrap',
+                    value: 'bootstrap'
+                }, {
+                    name: 'Config Client',
+                    value: 'configClient'
+                }, {
+                    name: 'Config Server',
+                    value: 'configServer'
+                }, {
+                    name: 'Eureka',
+                    value: 'eureka'
+                }, {
+                    name: 'Eureka Server',
+                    value: 'eurekaServer'
+                }, {
+                    name: 'Feign',
+                    value: 'feign'
+                }, {
+                    name: 'Hystrix',
+                    value: 'hystrix'
+                }, {
+                    name: 'Hystrix Dashboard',
+                    value: 'hystrixDashboard'
+                }, {
+                    name: 'OAuth2',
+                    value: 'oauth2'
+                }, {
+                    name: 'Ribbon',
+                    value: 'ribbon'
+                }, {
+                    name: 'Turbine',
+                    value: 'turbine'
+                }, {
+                    name: 'Turbine AMQP',
+                    value: 'turbineAmqp'
+                }, {
+                    name: 'Zuul',
+                    value: 'zuul'
+                }, {
+                    name: 'AWS',
+                    value: 'aws'
+                }, {
+                    name: 'AWS JDBC',
+                    value: 'awsJdbc'
+                }, {
+                    name: 'AWS Messaging',
+                    value: 'awsMessaging'
+                }, {
+                    name: 'Cloud Bus AMQP',
+                    value: 'cloudBus'
+                }, {
+                    name: 'Cloud Security',
+                    value: 'cloudSecurity'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'io',
+            message: 'Select I/O support:',
+            choices: [
+                {
+                    name: 'Batch',
+                    value: 'batch'
+                }, {
+                    name: 'Integration',
+                    value: 'integration'
+                }, {
+                    name: 'JMS (HornetQ)',
+                    value: 'jms'
+                }, {
+                    name: 'AMQP',
+                    value: 'amqp'
+                }, {
+                    name: 'Mail',
+                    value: 'mail'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'social',
+            message: 'Select Social APIs:',
+            choices: [
+                {
+                    name: 'Facebook',
+                    value: 'facebook'
+                }, {
+                    name: 'LinkedIn',
+                    value: 'linkedin'
+                }, {
+                    name: 'Twitter',
+                    value: 'twitter'
+                }
+            ]
+        }, {
+            type: 'checkbox',
+            name: 'ops',
+            message: 'Select OPS tools:',
+            choices: [
+                {
+                    name: 'Actuator',
+                    value: 'actuator'
+                }, {
+                    name: 'Remote Shell',
+                    value: 'remoteshell'
+                }
+            ]
+        }, {
             type: 'confirm',
             name: 'useSpock',
-            message: '(5/6) Would you like to use Spock?',
+            message: 'Use Spock?',
             default: true
-        },
-        {
-            type: 'confirm',
-            name: 'useWrapper',
-            message: '(6/6) Would you like to add the Gradle wrapper?',
-            default: true
+        }, {
+            type: 'string',
+            name: 'groovyVersion',
+            message: 'Enter Groovy version:',
+            default: '2.4.4'
+        }, {
+            type: 'string',
+            name: 'packagingType',
+            message: 'Package as jar or war?',
+            default: 'jar'
         }
     ];
 
-    this.prompt(prompts, function (props) {
+    this.prompt(prompts, function(props) {
+        this.bootVersion = props.bootVersion;
         this.packageName = props.packageName;
         this.baseName = props.baseName;
-        this.useWrapper = props.useWrapper;
-        this.bootVersion = props.bootVersion;
+        this.javaVersion = props.javaVersion;
+        this.coreWeb = props.coreWeb;
+        this.templates = props.templates;
+        this.data = props.data;
+        this.database = props.database;
+        this.cloud = props.cloud;
+        this.io = props.io;
+        this.social = props.social;
+        this.ops = props.ops;
         this.useSpock = props.useSpock;
-        this.starters = props.starters;
+        this.groovyVersion = props.groovyVersion;
+        this.packagingType = props.packagingType;
 
-        var hasStarter = function (starter) { return props.starters.indexOf(starter) !== -1; };
-        this.jetty = hasStarter('jetty');
-        this.actuator = hasStarter('actuator');
-        this.aop = hasStarter('aop');
-        this.batch = hasStarter('batch');
-        this.hateoas = hasStarter('hateoas');
-        this.jpa = hasStarter('jpa');
-        this.integration = hasStarter('integration');
-        this.jdbc = hasStarter('jdbc');
-        this.logging = hasStarter('logging');
-        this.security = hasStarter('security');
-        this.websocket = hasStarter('websocket');
+        // Core/Web
+        var hasCoreWeb = function(coreWebStarter) {
+            return props.coreWeb.indexOf(coreWebStarter) !== -1;
+        };
+        this.web = hasCoreWeb('web');
+        this.jetty = hasCoreWeb('jetty');
+        this.security = hasCoreWeb('security');
+        this.aop = hasCoreWeb('aop');
+        this.websocket = hasCoreWeb('websocket');
+        this.jersey = hasCoreWeb('jersey');
+        this.rest = hasCoreWeb('rest');
+        this.hateoas = hasCoreWeb('hateoas');
+        this.mobile = hasCoreWeb('mobile');
+
+        // Template Engines
+        var hasTemplate = function(templateStarter) {
+            return props.templates.indexOf(templateStarter) !== -1;
+        };
+        this.thymeleaf = hasTemplate('thymeleaf');
+        this.gtemplates = hasTemplate('gtemplates');
+        this.mustache = hasTemplate('mustache');
+
+        // Spring Data
+        var hasData = function(dataStarter) {
+            return props.data.indexOf(dataStarter) !== -1;
+        };
+        this.jdbc = hasData('jdbc');
+        this.jpa = hasData('jpa');
+        this.mongodb = hasData('mongodb');
+        this.redis = hasData('redis');
+        this.gemfire = hasData('gemfire');
+        this.solr = hasData('solr');
+        this.elasticsearch = hasData('elasticsearch');
+
+        // Databases
+        var hasDatabase = function(databaseStarter) {
+            return props.database.indexOf(databaseStarter) !== -1;
+        };
+        this.h2 = hasDatabase('h2');
+        this.hsqldb = hasDatabase('hsqldb');
+        this.derby = hasDatabase('derby');
+        this.mysql = hasDatabase('mysql');
+        this.postgresql = hasDatabase('postgresql');
+
+        // Spring Cloud
+        var hasCloud = function(cloudStarter) {
+            return props.cloud.indexOf(cloudStarter) !== -1;
+        };
+        this.connectors = hasCloud('connectors');
+        this.bootstrap = hasCloud('bootstrap');
+        this.configClient = hasCloud('configClient');
+        this.configServer = hasCloud('configServer');
+        this.eureka = hasCloud('eureka');
+        this.eurekaServer = hasCloud('eurekaServer');
+        this.feign = hasCloud('feign');
+        this.hystrix = hasCloud('hystrix');
+        this.hystrixDashboard = hasCloud('hystrixDashboard');
+        this.oauth2 = hasCloud('oauth2');
+        this.ribbon = hasCloud('ribbon');
+        this.turbine = hasCloud('turbine');
+        this.turbineAmqp = hasCloud('turbineAmqp');
+        this.zuul = hasCloud('zuul');
+        this.aws = hasCloud('aws');
+        this.awsJdbc = hasCloud('awsJdbc');
+        this.awsMessaging = hasCloud('awsMessaging');
+        this.cloudBus = hasCloud('cloudBus');
+        this.cloudSecurity = hasCloud('cloudSecurity');
+
+        // I/O
+        var hasIO = function(ioStarter) {
+            return props.io.indexOf(ioStarter) !== -1;
+        };
+        this.batch = hasIO('batch');
+        this.integration = hasIO('integration');
+        this.jms = hasIO('jms');
+        this.amqp = hasIO('amqp');
+        this.mail = hasIO('mail');
+
+        // Social
+        var hasSocial = function(socialStarter) {
+            return props.social.indexOf(socialStarter) !== -1;
+        };
+        this.facebook = hasSocial('facebook');
+        this.linkedin = hasSocial('linkedin');
+        this.twitter = hasSocial('twitter');
+
+        // OPS
+        var hasOps = function(opsStarter) {
+            return props.ops.indexOf(opsStarter) !== -1;
+        };
+        this.actuator = hasOps('actuator');
+        this.remoteshell = hasOps('remoteshell');
 
         cb();
     }.bind(this));
@@ -151,16 +409,12 @@ SpringGenerator.prototype.app = function app() {
     this.mkdir(srcDir);
     this.template('build.gradle', 'build.gradle');
     this.template('Application.java', srcDir + '/Application.java');
-
-    if(this.useSpock){
+    if (this.useSpock) {
         var testDir = 'src/test/groovy/' + packageFolder;
         this.mkdir(testDir);
     }
-
     this.config.set('packageName', this.packageName);
     this.config.set('packageFolder', packageFolder);
 };
 
-SpringGenerator.prototype.projectfiles = function projectfiles() {
-
-};
+SpringGenerator.prototype.projectfiles = function projectfiles() {};

--- a/app/templates/Application.java
+++ b/app/templates/Application.java
@@ -1,11 +1,9 @@
 package <%=packageName%>;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.SpringApplication;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@ComponentScan
-@EnableAutoConfiguration
+@SpringBootApplication
 public class Application {
 
     public static void main(String[] args) {

--- a/app/templates/build.gradle
+++ b/app/templates/build.gradle
@@ -1,59 +1,116 @@
 buildscript {
+
     repositories {
-        maven { url 'http://repo.springsource.org/libs-snapshot' }
-        mavenLocal()
+        mavenCentral()
     }
     dependencies {
-        classpath('org.springframework.boot:spring-boot-gradle-plugin:<%= bootVersion %>')
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:<%= bootVersion %>")
+        classpath("io.spring.gradle:dependency-management-plugin:0.5.2.RELEASE")
     }
 }
 
-<% if( useSpock ){%>
-apply plugin: 'groovy'
-<% } else { %>
 apply plugin: 'java'
-<% } %>
+apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'spring-boot'
+apply plugin: 'io.spring.dependency-management'
 
-jar {
-    baseName = '<%= baseName %>'
-    version =  '0.1.0'
-}
+sourceCompatibility = '<%= javaVersion %>'
+targetCompatibility = '<%= javaVersion %>'
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.springsource.org/libs-snapshot' }
 }
 
 dependencies {
-    compile('org.springframework.boot:spring-boot-starter-web:<%= bootVersion %>')<% if( jetty ){ %>{
-        exclude module: 'spring-boot-starter-tomcat'
+    <% if (web) { %>compile("org.springframework.boot:spring-boot-starter-web:<%= bootVersion %>")<% if (jetty) { %> {
+        exclude module: "spring-boot-starter-tomcat"
     }
-    compile 'org.springframework.boot:spring-boot-starter-jetty:<%= bootVersion %>'<% } %>
-    compile 'org.thymeleaf:thymeleaf-spring3:2.0.17'
-    <% if( actuator ){ %>compile 'org.springframework.boot:spring-boot-starter-actuator:<%= bootVersion %>'<% } %>
-    <% if( batch ){ %>compile 'org.springframework.boot:spring-boot-starter-batch:<%= bootVersion %>'<% } %>
-    <% if( jdbc ){ %>compile 'org.springframework.boot:spring-boot-starter-jdbc:<%= bootVersion %>'<% } %>
-    <% if( jpa ){ %>compile 'org.springframework.boot:spring-boot-starter-data-jpa:<%= bootVersion %>'<% } %>
-    <% if( hateoas ){ %>compile 'com.fasterxml.jackson.core:jackson-databind'
-    compile 'org.springframework.hateoas:spring-hateoas:0.7.0.RELEASE'<% } %>
-    <% if( integration ){ %>compile 'org.springframework.boot:spring-boot-starter-integration:<%= bootVersion %>'<% } %>
-    <% if( logging ){ %>compile 'org.springframework.boot:spring-boot-starter-logging:<%= bootVersion %>'<% } %>
-    <% if( security ){ %>compile 'org.springframework.boot:spring-boot-starter-security:<%= bootVersion %>'<% } %>
-    <% if( websocket ){ %>compile 'org.springframework.boot:spring-boot-starter-websocket:<%= bootVersion %>'<% } %>
-    <% if( useSpock ) {%>testCompile 'org.codehaus.groovy:groovy-all:2.1.7'
-    testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'<%}%>
+    compile("org.springframework.boot:spring-boot-starter-jetty:<%= bootVersion %>")<% } %>
+    <% } %>
+    <% if (security) { %>compile("org.springframework.boot:spring-boot-starter-security:<%= bootVersion %>")<% } %>
+    <% if (aop) { %>compile("org.springframework.boot:spring-boot-starter-aop:<%= bootVersion %>")<% } %>
+    <% if (websocket) { %>compile("org.springframework.boot:spring-boot-starter-websocket:<%= bootVersion %>")<% } %>
+    <% if (jersey) { %>compile("org.springframework.boot:spring-boot-starter-jersey:<%= bootVersion %>")<% } %>
+    <% if (rest) { %>compile("org.springframework.boot:spring-boot-starter-data-rest:<%= bootVersion %>")<% } %>
+    <% if (hateoas) { %>compile("org.springframework.boot:spring-boot-starter-hateoas:<%= bootVersion %>")<% } %>
+    <% if (mobile) { %>compile("org.springframework.boot:spring-boot-starter-mobile:<%= bootVersion %>")<% } %>
+
+    <% if (thymeleaf) { %>compile("org.springframework.boot:spring-boot-starter-thymeleaf:<%= bootVersion %>")<% } %>
+    <% if (gtemplates) { %>compile("org.springframework.boot:spring-boot-starter-groovy-templates:<%= bootVersion %>")<% } %>
+    <% if (mustache) { %>compile("org.springframework.boot:spring-boot-starter-mustache:<%= bootVersion %>")<% } %>
+
+    <% if (jdbc) { %>compile("org.springframework.boot:spring-boot-starter-jdbc:<%= bootVersion %>")<% } %>
+    <% if (jpa) { %>compile("org.springframework.boot:spring-boot-starter-data-jpa:<%= bootVersion %>")<% } %>
+    <% if (mongodb) { %>compile("org.springframework.boot:spring-boot-starter-data-mongodb:<%= bootVersion %>")<% } %>
+    <% if (redis) { %>compile("org.springframework.boot:spring-boot-starter-redis:<%= bootVersion %>")<% } %>
+    <% if (solr) { %>compile("org.springframework.boot:spring-boot-starter-data-solr:<%= bootVersion %>")<% } %>
+    <% if (elasticsearch) { %>compile("org.springframework.boot:spring-boot-starter-data-elasticsearch:<%= bootVersion %>")<% } %>
+
+    <% if (connectors) { %>compile("org.springframework.boot:spring-boot-starter-cloud-connectors")<% } %>
+    <% if (bootstrap) { %>compile("org.springframework.cloud:spring-cloud-starter")<% } %>
+    <% if (configClient) { %>compile("org.springframework.cloud:spring-cloud-starter-config")<% } %>
+    <% if (configServer) { %>compile("org.springframework.cloud:spring-cloud-config-server")<% } %>
+    <% if (eureka) { %>compile("org.springframework.cloud:spring-cloud-starter-eureka")<% } %>
+    <% if (eurekaServer) { %>compile("org.springframework.cloud:spring-cloud-starter-eureka-server")<% } %>
+    <% if (feign) { %>compile("org.springframework.cloud:spring-cloud-starter-feign")<% } %>
+    <% if (hystrix) { %>compile("org.springframework.cloud:spring-cloud-starter-hystrix")<% } %>
+    <% if (hystrixDashboard) { %>compile("org.springframework.cloud:spring-cloud-starter-hystrix-dashboard")<% } %>
+    <% if (oauth2) { %>compile("org.springframework.cloud:spring-cloud-starter-oauth2")<% } %>
+    <% if (ribbon) { %>compile("org.springframework.cloud:spring-cloud-starter-ribbon")<% } %>
+    <% if (turbine) { %>compile("org.springframework.cloud:spring-cloud-starter-turbine")<% } %>
+    <% if (turbineAmqp) { %>compile("org.springframework.cloud:spring-cloud-starter-turbine-amqp")<% } %>
+    <% if (zuul) { %>compile("org.springframework.cloud:spring-cloud-starter-zuul")<% } %>
+    <% if (aws) { %>compile("org.springframework.cloud:spring-cloud-starter-aws")<% } %>
+    <% if (awsJdbc) { %>compile("org.springframework.cloud:spring-cloud-starter-aws-jdbc")<% } %>
+    <% if (awsMessaging) { %>compile("org.springframework.cloud:spring-cloud-starter-aws-messaging")<% } %>
+    <% if (cloudBus) { %>compile("org.springframework.cloud:spring-cloud-starter-bus-amqp")<% } %>
+    <% if (cloudSecurity) { %>compile("org.springframework.cloud:spring-cloud-starter-security")<% } %>
+
+    <% if (batch) { %>compile("org.springframework.boot:spring-boot-starter-batch:<%= bootVersion %>")<% } %>
+    <% if (integration) { %>compile("org.springframework.boot:spring-boot-starter-integration:<%= bootVersion %>")<% } %>
+    <% if (jms) { %>compile("org.springframework.boot:spring-boot-starter-hornetq:<%= bootVersion %>")<% } %>
+    <% if (amqp) { %>compile("org.springframework.boot:spring-boot-starter-amqp:<%= bootVersion %>")<% } %>
+    <% if (mail) { %>compile("org.springframework.boot:spring-boot-starter-mail:<%= bootVersion %>")<% } %>
+
+    <% if (facebook) { %>compile("org.springframework.boot:spring-boot-starter-social-facebook:<%= bootVersion %>")<% } %>
+    <% if (linkedin) { %>compile("org.springframework.boot:spring-boot-starter-social-linkedin:<%= bootVersion %>")<% } %>
+    <% if (twitter) { %>compile("org.springframework.boot:spring-boot-starter-social-twitter:<%= bootVersion %>")<% } %>
+
+    <% if (actuator) { %>compile("org.springframework.boot:spring-boot-starter-actuator:<%= bootVersion %>")<% } %>
+    <% if (remoteshell) { %>compile("org.springframework.boot:spring-boot-starter-remote-shell:<%= bootVersion %>")<% } %>
+
+    compile("org.codehaus.groovy:groovy:<%= groovyVersion %>")
+
+    <% if (h2) { %>runtime("com.h2database:h2")<% } %>
+    <% if (hsqldb) { %>runtime("org.hsqldb:hsqldb")<% } %>
+    <% if (derby) { %>runtime("org.apache.derby:derby")<% } %>
+    <% if (mysql) { %>runtime("mysql:mysql-connector-java")<% } %>
+    <% if (postgresql) { %>runtime("org.postgresql:postgresql:9.4-1201-jdbc41")<% } %>
+
+    <% if (useSpock) { %>
+    testCompile("org.spockframework:spock-spring")
+    testCompile("org.spockframework:spock-core:1.0-groovy-2.4")
+    <% } %>
+    <% if (web) { %>testCompile("org.springframework.boot:spring-boot-starter-test:<%= bootVersion %>")<% } %>
 }
 
-task run(type:Exec){
-    commandLine "java -jar build/libs/<%=baseName%>-0.1.0.jar".split(' ')
+dependencyManagement {
+  imports {
+    mavenBom("org.springframework.cloud:spring-cloud-starter-parent:Angel.SR3")
+  }
 }
+<% if (packagingType === 'jar') { %>
+jar {
+    baseName = '<%= baseName %>'
+    version =  "0.0.1"
+}<% } %>
+<% if (packagingType === 'war') { %>
+war {
+    baseName =  '<%= baseName %>'
+    version = "0.0.1"
+}<% } %>
 
-run.dependsOn build
-
-<% if( useWrapper ){ %>
 task (type: Wrapper) {
-    gradleVersion = '1.8'
+    gradleVersion = '2.3'
 }
-<% } %>

--- a/app/templates/build.gradle
+++ b/app/templates/build.gradle
@@ -79,7 +79,6 @@ dependencies {
 
     <% if (actuator) { %>compile("org.springframework.boot:spring-boot-starter-actuator:<%= bootVersion %>")<% } %>
     <% if (remoteshell) { %>compile("org.springframework.boot:spring-boot-starter-remote-shell:<%= bootVersion %>")<% } %>
-
     compile("org.codehaus.groovy:groovy:<%= groovyVersion %>")
 
     <% if (h2) { %>runtime("com.h2database:h2")<% } %>
@@ -95,11 +94,13 @@ dependencies {
     <% if (web) { %>testCompile("org.springframework.boot:spring-boot-starter-test:<%= bootVersion %>")<% } %>
 }
 
+<% if (usesCloud) { %>
 dependencyManagement {
   imports {
     mavenBom("org.springframework.cloud:spring-cloud-starter-parent:Angel.SR3")
   }
 }
+<% } %>
 <% if (packagingType === 'jar') { %>
 jar {
     baseName = '<%= baseName %>'


### PR DESCRIPTION
This is an effort to make this tool a complete CLI alternative to Spring Initializr. This set of changes add, roughtly, mirrored dependency support to what the [start.spring.io](http://start.spring.io) site offers, including the Spring Cloud suite of tools. But continues, at the moment, to take an opinionated approach on the build tool by using Gradle. A future change could add Maven support.

I've left the `spring:rest`, `spring:hateoas` and `spring:routes` sub-generators as is. Also, I've taken liberty in modifying the README to make is a bit more lean. 

I think this is a great tool and would love to keep evolving it.
